### PR TITLE
check for bad paths for better error reporting

### DIFF
--- a/sim/simulator.wake
+++ b/sim/simulator.wake
@@ -1,7 +1,3 @@
-def mustPass x = match x
-  Pass a = a
-  Fail b = panic b.format
-
 tuple TestFailed =
   global Msg:    String
   global Status: Option Integer
@@ -34,8 +30,8 @@ global def getTestResultStatus = match _
 
 tuple SimulationOutput =
   Outputs_: List Path
-  Stdout_:  String
-  Stderr_:  String
+  Stdout_:  Result String Error
+  Stderr_:  Result String Error
   Status_:  Integer
 
 def peelStatus = match _
@@ -46,8 +42,8 @@ def peelStatus = match _
 global def makeSimulationOutput job =
   SimulationOutput
   job.getJobFailedOutputs
-  (mustPass job.getJobStdout)
-  (mustPass job.getJobStderr)
+  job.getJobStdout
+  job.getJobStderr
   (peelStatus job.getJobStatus)
 
 global def getSimulationOutputOutputs = getSimulationOutputOutputs_

--- a/sim/vcs.wake
+++ b/sim/vcs.wake
@@ -82,10 +82,15 @@ global def doVCSCompile options =
 
   def simv =
     def simvFilename = "{outputDir}/simv"
-    def findSimv = find (matches simvFilename.quote _.getPathName) vcsOutputs
+    def findSimv =
+      vcsOutputs
+      | map getPathResult
+      | findFail
+      | rmap (\_ find (matches simvFilename.quote _.getPathName) vcsOutputs)
     match findSimv
-      None            = "VCS compile failed!".makeError.makeBadPath
-      Some (Pair s _) = s
+      Fail e = e.makeBadPath
+      Pass (Some (Pair s _)) = s
+      Pass (None) = "VCS compile failed: no simv found".makeError.makeBadPath
 
   VCSCompileOutputs vcsOutputs options simv
 

--- a/top.wake
+++ b/top.wake
@@ -96,8 +96,16 @@ global def singleSimTarget simName waves dut buildRoot dutTest =
 
     def result dut outputs options =
       def statusFile =
-        outputs.getSimulationOutputOutputs
-        | find (matches `([^/]*/)*status\.log` _.getPathName)
+        def result =
+          def simOutputs = outputs.getSimulationOutputOutputs
+          simOutputs
+          | map getPathResult
+          | findFail
+          | rmap (\_ find (matches `([^/]*/)*status\.log` _.getPathName) simOutputs)
+        match result
+          Pass (Some (Pair f _)) = f
+          Pass (None) = "no status.log file found".makeError.makeBadPath
+          Fail e = e.makeBadPath
 
       def checkStatus statusFileContents =
         def failRegex = `^FAILED with status (.*)$`
@@ -112,15 +120,23 @@ global def singleSimTarget simName waves dut buildRoot dutTest =
           None          False = makeTestResultFail statusFileContents None
           (Some status) _     = makeTestResultFail statusFileContents status.int
 
-      #not ideal. silent fail
-      def testResult = match statusFile
-        Some (Pair f _) = f | read | getWhenFail '' | checkStatus
-        None            = makeTestResultFail "FAILED: could not read status.log!" None
+      def testResult =
+        def statusResult =
+          statusFile
+          | read
+          | rmap checkStatus
+        match statusResult
+          Pass status = status
+          Fail e = makeTestResultFail e.getErrorCause None
       testResult
 
     def reporter dut outputs options =
-      def simErr = write "{options.getSimCheckerOptionsOutputDir}/sim.err" outputs.getSimulationOutputStderr
-      def simOut = write "{options.getSimCheckerOptionsOutputDir}/sim.out" outputs.getSimulationOutputStdout
+      def simErr = match outputs.getSimulationOutputStderr
+        Fail e = makeBadPath e
+        Pass contents = write "{options.getSimCheckerOptionsOutputDir}/sim.err" contents
+      def simOut = match outputs.getSimulationOutputStdout
+        Fail e = makeBadPath e
+        Pass contents = write "{options.getSimCheckerOptionsOutputDir}/sim.out" contents
       match (result dut outputs options)
         TestFail failed = "FAILED: {failed.getTestFailedMsg}"
         TestPass passed = passed.getTestPassedMsg


### PR DESCRIPTION
`runSim` tends to fail with unhelpful error messages because we aren't checking for bad paths