### PR TITLE
make makeVCSDUTSimulatorPlan global, remove addHfclk

### DIFF
--- a/program/freedom-metal-program.wake
+++ b/program/freedom-metal-program.wake
@@ -134,7 +134,6 @@ global target fixupDTS dts metalEntryPairOpt romNode ramNode =
       | addChosenNode
       | addStdoutChosenFromAlias
       | (omap addEntry metalEntryPairOpt | getOrElse (_))
-      | addHfclk clkFrequency
       | (omap "metal,rom".addChosenRef romNode | getOrElse (_))
       | (omap "metal,ram".addChosenRef ramNode | getOrElse (_))
       | catWith "\n"

--- a/program/freedom-metal-program.wake
+++ b/program/freedom-metal-program.wake
@@ -59,31 +59,11 @@ def addSocSubnodeField subnodeRegex (Pair fieldName fieldValue) inDTSContents =
   else
     inDTSContents
 
-def addHfclk frequency dtsContents =
-  if exists `^\t\tstdout-path = .*$`.matches dtsContents
-  then
-    def hfclkField = Pair "clocks" "<&hfclk>"
-    def hfclkNode =
-      "\t\thfclk: clock@0 \{",
-      "\t\t\t#clock-cells = <0>;",
-      "\t\t\tcompatible = \"fixed-clock\";",
-      "\t\t\tclock-frequency = <{str frequency}>;",
-      "\t\t\};",
-      "",
-      Nil
-    dtsContents
-    | addSocSubnode hfclkNode
-    | addSocSubnodeField `(L[a-zA-Z0-9_]+:\s)?serial@[0-9]+` hfclkField
-  else
-    dtsContents
-
 def splitTo f l =  match l
   Nil  = Pair Nil Nil
   h, t if f h = Pair (h, Nil) t
   h, t = match (splitTo f t)
     Pair f s = Pair (h, f) s
-
-def addSocSubnode = addSubnode `(L[a-zA-Z0-9_]+:\s)?soc`
 
 def addChosenSubnode = addSubnode `(L[a-zA-Z0-9_]+:\s)?chosen`
 

--- a/sim/vcs-sim.wake
+++ b/sim/vcs-sim.wake
@@ -5,7 +5,7 @@ tuple VCSDUTSimulatorPlan =
   global CompileOptions: DUT => PrivateVCSDUTSimCompileOptions
   global ExecuteOptions: DUT => PrivateVCSDUTSimExecuteOptions
 
-def makeVCSDUTSimulatorPlan testDriver waves score compileOptions executeOptions =
+global def makeVCSDUTSimulatorPlan testDriver waves score compileOptions executeOptions =
   VCSDUTSimulatorPlan testDriver waves score compileOptions executeOptions
 
 

--- a/sim/verilator-sim.wake
+++ b/sim/verilator-sim.wake
@@ -5,7 +5,7 @@ tuple VerilatorDUTSimulatorPlan =
   global CompileOptions: DUT => PrivateVerilatorDUTSimCompileOptions
   global ExecuteOptions: DUT => PrivateVerilatorDUTSimExecuteOptions
 
-def makeVerilatorDUTSimulatorPlan testDriver waves score compileOptions executeOptions =
+global def makeVerilatorDUTSimulatorPlan testDriver waves score compileOptions executeOptions =
   VerilatorDUTSimulatorPlan testDriver waves score compileOptions executeOptions
 
 

--- a/sim/xcelium-sim.wake
+++ b/sim/xcelium-sim.wake
@@ -5,7 +5,7 @@ tuple XceliumDUTSimulatorPlan =
   global CompileOptions: DUT => PrivateXceliumDUTSimCompileOptions
   global ExecuteOptions: DUT => PrivateXceliumDUTSimExecuteOptions
 
-def makeXceliumDUTSimulatorPlan testDriver waves score compileOptions executeOptions =
+global def makeXceliumDUTSimulatorPlan testDriver waves score compileOptions executeOptions =
   XceliumDUTSimulatorPlan testDriver waves score compileOptions executeOptions
 
 


### PR DESCRIPTION
`addHfclk` is no longer needed since rocket chip has https://github.com/chipsalliance/rocket-chip/blob/master/src/main/scala/diplomacy/FixedClockResource.scala. I don't think it ever was needed, we just didn't know how to do it in scala. also make `make{VCS|Verilator|Xcelium}DUTSimulatorPlan` global so other people can actually make their own `DUTSimulator`s