### PR TITLE
make stdout-path chosen node configurable

### DIFF
--- a/program/freedom-metal-program.wake
+++ b/program/freedom-metal-program.wake
@@ -74,20 +74,23 @@ def addSubnode parentNode node inDTSContents =
     Pair (firstSplit.getPairFirst ++ secondSplit.getPairFirst) (secondSplit.getPairSecond)
   split.getPairFirst ++ node ++ split.getPairSecond
 
-def addStdoutChosenFromAlias inDTSContents =
+def addStdoutChosenFromAlias nodeName inDTSContents =
   def parentNode = `(L[a-zA-Z0-9_]+:\s)soc`
   def firstSplit = splitTo (`^\t`, parentNode, `\s{$`, Nil).regExpCat.matches inDTSContents
   def secondSplit = splitUntil `\t\};$`.matches firstSplit.getPairSecond
   def socContents = secondSplit.getPairFirst
   def baudrate = 115200
-  def serialNodes =
-    map `^\t\t(?:L[a-zA-Z0-9_]+:\s)?(serial@[0-9]+)\s{$`.extract socContents | flatten
-  match serialNodes
-    serialNode, _ =
-      def stdChosen =
-        "\t\tstdout-path = \"/soc/{serialNode}:{str baudrate}\";", Nil
-      addChosenSubnode stdChosen inDTSContents
-    _ = inDTSContents
+  match "({regExpToString nodeName.quote}@[0-9]+)".stringToRegExp
+    Fail e = inDTSContents
+    Pass nodeRegex =
+      def regex = regExpCat (`^\t\t(?:L[0-9]+:\s)?`, nodeRegex, `\s{$`, Nil)
+      def serialNodes = map regex.extract socContents | flatten
+      match serialNodes
+        serialNode, _ =
+          def stdChosen =
+            "\t\tstdout-path = \"/soc/{serialNode}:{str baudrate}\";", Nil
+          addChosenSubnode stdChosen inDTSContents
+        _ = inDTSContents
 
 def addChosenNode inDTSContents =
   def parentNode = "/"
@@ -100,7 +103,7 @@ def addChosenNode inDTSContents =
   ++ chosenNode
   ++ secondSplit.getPairSecond
 
-global target fixupDTS dts metalEntryPairOpt romNode ramNode =
+global target fixupDTS dts stdoutPath metalEntryPairOpt romNode ramNode =
   def clkFrequency = 32500000
   def prefix =
     extract `(.*)\.dts` dts.getPathName
@@ -112,7 +115,7 @@ global target fixupDTS dts metalEntryPairOpt romNode ramNode =
       dtsContents
       | tokenize `\n`
       | addChosenNode
-      | addStdoutChosenFromAlias
+      | (omap addStdoutChosenFromAlias stdoutPath | getOrElse (_))
       | (omap addEntry metalEntryPairOpt | getOrElse (_))
       | (omap "metal,rom".addChosenRef romNode | getOrElse (_))
       | (omap "metal,ram".addChosenRef ramNode | getOrElse (_))
@@ -205,6 +208,7 @@ global def freedomMetalDUTProgramCompiler =
     def metalInstall =
       fixupDTS
       dut.getRocketChipDUTDTS
+      programCompileOptions.getProgramCompileOptionsStdoutPath
       programCompileOptions.getProgramCompileOptionsEntry
       programCompileOptions.getProgramCompileOptionsRom
       programCompileOptions.getProgramCompileOptionsRam

--- a/program/program.wake
+++ b/program/program.wake
@@ -97,9 +97,9 @@ tuple ProgramCompileOptions =
   global OutputDir:   String
   global Filter:      DUTProgramCompiler => Boolean
   global Entry:       Option (Pair String Integer)
-  global Rom:         Option String
-  global Ram:         Option String
-  global StdoutPath:  Option String
+  global Rom:         Option String # name of the DTS node to set the 'metal,rom' chosen node to
+  global Ram:         Option String # name of the DTS node to set the 'metal,ram' chosen node to
+  global StdoutPath:  Option String # name of the DTS node to set the 'stdout-path' chosen node to
 
 global def makeProgramCompileOptions name cflags cfiles outputDir =
   def asFlags     = Nil

--- a/program/program.wake
+++ b/program/program.wake
@@ -37,9 +37,9 @@ tuple TestProgramPlan =
   global Sources:     List Path
   global Filter:      DUTProgramCompiler => Boolean
   global Entry:       Option (Pair String Integer)
-  global Rom:         Option String
-  global Ram:         Option String
-  global StdoutPath:  Option String
+  global Rom:         Option String # name of the DTS node to set the 'metal,rom' chosen node to
+  global Ram:         Option String # name of the DTS node to set the 'metal,ram' chosen node to
+  global StdoutPath:  Option String # name of the DTS node to set the 'stdout-path' chosen node to
 
 global def makeTestProgramPlan name cfiles =
   TestProgramPlan

--- a/program/program.wake
+++ b/program/program.wake
@@ -39,6 +39,7 @@ tuple TestProgramPlan =
   global Entry:       Option (Pair String Integer)
   global Rom:         Option String
   global Ram:         Option String
+  global StdoutPath:  Option String
 
 global def makeTestProgramPlan name cfiles =
   TestProgramPlan
@@ -52,6 +53,7 @@ global def makeTestProgramPlan name cfiles =
   None
   None
   None
+  (Some "simSerial")
 
 global def testProgramPlanToProgramCompileOptions plan outputDir =
   def name        = plan.getTestProgramPlanName
@@ -64,6 +66,7 @@ global def testProgramPlanToProgramCompileOptions plan outputDir =
   def entry       = plan.getTestProgramPlanEntry
   def rom         = plan.getTestProgramPlanRom
   def ram         = plan.getTestProgramPlanRam
+  def stdoutPath  = plan.getTestProgramPlanStdoutPath
 
   ProgramCompileOptions
   name
@@ -77,6 +80,7 @@ global def testProgramPlanToProgramCompileOptions plan outputDir =
   entry
   rom
   ram
+  stdoutPath
 
 global def testProgramPlanToGCCProgramPlan outputFile plan =
   testProgramPlanToProgramCompileOptions plan "{outputFile}/..".simplify
@@ -95,6 +99,7 @@ tuple ProgramCompileOptions =
   global Entry:       Option (Pair String Integer)
   global Rom:         Option String
   global Ram:         Option String
+  global StdoutPath:  Option String
 
 global def makeProgramCompileOptions name cflags cfiles outputDir =
   def asFlags     = Nil
@@ -104,7 +109,9 @@ global def makeProgramCompileOptions name cflags cfiles outputDir =
   def entry = None
   def rom = None
   def ram = None
-  ProgramCompileOptions name cflags asFlags cfiles includeDirs sources outputDir filter entry rom ram
+  def stdoutPath = None
+
+  ProgramCompileOptions name cflags asFlags cfiles includeDirs sources outputDir filter entry rom ram stdoutPath
 
 global def programCompileOptionsToGCCProgramPlan outputFile plan =
   def name        = plan.getProgramCompileOptionsName


### PR DESCRIPTION
`stdout-path` is set to the first `serial` node found in the DTS. however the `SimUART` and the real `UART` from sifive-blocks have the same DTS name, which can mess up the `stdout-path`.

This PR adds a `StdoutPath` option to the `TestProgramPlan` tuple to enable configuring this chosen node like we do for entry, ram, and rom. It also changes the default stdout-path node to `simSerial` instead of `serial` in `makeTestProgramPlan` since we usually want `stdout-path` to be the `SimUART` for test programs.

This will break old test plans that expect stdout-path to look for a `serial` node. 