### PR TITLE
set filename option for rocket-chip generator

### DIFF
--- a/dut/rocket-chip-dut.wake
+++ b/dut/rocket-chip-dut.wake
@@ -104,6 +104,7 @@ def doRocketGenerate dutPlan userArgs =
   def testharness = dutPlan.getRocketChipDUTPlanTestharness
 
   makeRocketChipGeneratorOptions jars firrtlDir testharness configs
+  | setRocketChipGeneratorOptionsBaseFileName (Some dutPlan.getRocketChipDUTPlanName)
   | runRocketChipGenerator
 
 def doVLSIROMGen dutPlan userArgs rocketOutputs =

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -10,7 +10,7 @@
         "source": "git@github.com:sifive/freedom-devicetree-tools.git"
     },
     {
-        "commit": "50de8a34c19c12de5066cd7ada50ebb5f5b2ea26",
+        "commit": "43e2c8e776e1bde2e78914a08fe8963ca42ff1f0",
         "name": "rocket-chip",
         "source": "git@github.com:chipsalliance/rocket-chip.git"
     },


### PR DESCRIPTION
bump rocket-chip to this commit https://github.com/chipsalliance/rocket-chip/pull/2049/commits/43e2c8e776e1bde2e78914a08fe8963ca42ff1f0

set the base filename for rocket-chip outputs so we can avoid `File name too long` errors