### PR TITLE
Use new Freedom Metal Python-based tools

### DIFF
--- a/dut/dut.wake
+++ b/dut/dut.wake
@@ -11,6 +11,7 @@ tuple DUT =
   #global Missing:     List Resource
   global DTS:          Path
   global DTSJSON:      Path # JSON version of DTS
+  global CustomOverlay: Option DevicetreeCustomOverlay
   global FPGABoardOpt: Option String
   global Sources:      List Path
   global ObjectModelFile: Path
@@ -20,7 +21,7 @@ global def makeDUT name configs objectModel vsrcs topModule missing dts dtsJSON 
     objectModel
     | prettyJSON
     | write "build/api-generator-sifive/{name}/programs/omfile.json"
-  DUT name configs objectModel vsrcs topModule missing dts dtsJSON board Nil omFile
+  DUT name configs objectModel vsrcs topModule missing dts dtsJSON None board Nil omFile
 
 global def sourcesInDUT regex dut =
   dut.getDUTSources

--- a/dut/rocket-chip-dut.wake
+++ b/dut/rocket-chip-dut.wake
@@ -12,6 +12,8 @@ tuple RocketChipDUTPlan =
   global ScalaModules:     List ScalaModule
   global ExtraSources:     List Path
   global FirrtlTransforms: List String
+  global CustomOverlay:    Option DevicetreeCustomOverlay
+  global FPGABoardOpt:     Option String
 
 tuple RuntimeRocketChipDUTArgs =
   global FirrtlDir:  Path
@@ -42,6 +44,8 @@ global def makeRocketChipDUTPlan name module testharness config =
   (module, Nil)  # ScalaModules List ScalaModules
   Nil
   Nil
+  None
+  None
 
 global def addRocketChipDUTPlanScalaBlock scalaBlock plan =
   plan
@@ -91,7 +95,10 @@ global def rocketChipDUTMaker dutPlan userArgs =
     (Pass objectModel) (Some topModule) =
       def name = dutPlan.getRocketChipDUTPlanName
       def configs = dutPlan.getRocketChipDUTPlanConfigs
-      makeDUT name configs objectModel vsrcs topModule blackboxes dts dtsJSON None
+      def customOverlay = dutPlan.getRocketChipDUTPlanCustomOverlay
+      def fpgaBoardOpt = dutPlan.getRocketChipDUTPlanFPGABoardOpt
+      makeDUT name configs objectModel vsrcs topModule blackboxes dts dtsJSON fpgaBoardOpt
+      | setDUTCustomOverlay customOverlay
       | setDUTSources allOutputs
       | Pass
     (Fail e) _ = Fail e

--- a/program/freedom-metal-program.wake
+++ b/program/freedom-metal-program.wake
@@ -4,6 +4,18 @@ tuple FreedomMakeAttributes =
   global MABI:   String
   global CMODEL: String
 
+#########################################################
+# runFreedomMakeAttributesGenerator
+#
+# Wraps the esdk-settings-generator and produces both
+# the Makefile fragment for augmenting the build of
+# Freedom Metal, but extracts the ABI, arch, and code
+# model to pass to the compiler.
+#
+# Arguments:
+#  - options: created by makeESDKSettingsGeneratorOptions
+#
+#########################################################
 global def runFreedomMakeAttributesGenerator options =
   def attributes =
     options
@@ -38,7 +50,7 @@ global def makeFreedomBSP coreDTS customOverlay type prefix =
     match customOverlay
       Some overlay =
         # Add coreDTS to the include list in the overlay
-        def coreFilename = extract `.*/(.*)` coreDTS.getPathName | head | getOrElse coreDTS.getPathName
+        def coreFilename = relative "{designDTSName}/.." coreDTS.getPathName
         def list = coreFilename, Nil ++ overlay.getDevicetreeCustomOverlayIncludes
         overlay
         | setDevicetreeCustomOverlayIncludes list
@@ -71,17 +83,15 @@ global def makeFreedomBSP coreDTS customOverlay type prefix =
     makeESDKSettingsGeneratorOptions designDTS (coreDTS, Nil) type "{prefix}.mk"
     | runFreedomMakeAttributesGenerator
 
-  match attributesResult
-    Pass attributes =
-      Pass (
-        FreedomBSP
-        linkerScript
-        header.getFreedomMetalHeaderGeneratorOutputsHeader
-        header.getFreedomMetalHeaderGeneratorOutputsInlineHeader
-        platformHeader
-        attributes
-      )
-    Fail err = Fail err
+  attributesResult |
+  rmap (\attributes
+  FreedomBSP
+  linkerScript
+  header.getFreedomMetalHeaderGeneratorOutputsHeader
+  header.getFreedomMetalHeaderGeneratorOutputsInlineHeader
+  platformHeader
+  attributes
+  )
 
 global def generateMetalFromDts dts machineName customOverlay type outputDir =
   def prefix = "{outputDir}/{machineName}"
@@ -164,9 +174,7 @@ global def freedomMetalDUTProgramCompiler =
       | distinctBy (scmp _.getPathName _.getPathName)
 
     def outputDir = programCompileOptions.getProgramCompileOptionsOutputDir
-    def type = match dut.getDUTFPGABoardOpt
-      None     = "rtl"
-      Some opt = opt
+    def type = dut.getDUTFPGABoardOpt | getOrElse "rtl"
     def installDir = "build/freedom-metal/{dut.getDUTName}"
     def metalInstall =
       generateMetalFromDts dut.getRocketChipDUTDTS dut.getDUTName dut.getDUTCustomOverlay type installDir

--- a/program/freedom-metal-program.wake
+++ b/program/freedom-metal-program.wake
@@ -1,127 +1,79 @@
-# takes a device tree property name and a subnode type and injects a reference
-# to the first occurance of that subnode type to the chosen node
-def addChosenRef name socSubNode inDTSContents =
-  def subnodeOpt =
-    match "({socSubNode}@[a-fA-F0-9]+)".stringToRegExp
-      Pass regex =
-        def nodeRegex = regExpCat (`^\t\t`, `(?:L[a-zA-Z0-9_]+:\s)?`, regex, `\s{$`, Nil)
-        inDTSContents
-        | map nodeRegex.extract
+tuple FreedomMakeAttributes =
+  global File:   Path
+  global MARCH:  String
+  global MABI:   String
+  global CMODEL: String
+
+global def runFreedomMakeAttributesGenerator options =
+  def attributes =
+    options
+    | runESDKSettingsGenerator
+    | getJobOutput
+
+  def rlines = read attributes | rmap `\n`.tokenize
+  match rlines
+    Pass lines =
+      def getAttribute attribute =
+        def regex = regExpCat (`^`, attribute, ` = (.*)$`, Nil)
+        lines
+        | map regex.extract
         | flatten
         | head
-        | omap ("/soc/{_}")
-      Fail _ = None
+      match `RISCV_ABI`.getAttribute `RISCV_ARCH`.getAttribute `RISCV_CMODEL`.getAttribute
+        (Some mabi) (Some march) (Some cmodel) = Pass (FreedomMakeAttributes attributes march mabi cmodel)
+        _ _ _ = Fail "Generated make attributes file not formatted correctly: {attributes.getPathName}".makeError
+    Fail fail = Fail fail
 
-  match subnodeOpt
-    Some subnode =
-      inDTSContents
-      | mapFlat (\a (
-        if matches `^\tchosen\s{$` a
-        then ("\tchosen \{", "\t\t{name} = <&\{{subnode}\}>;", Nil)
-        else a, Nil
-      ))
-    None = inDTSContents
+tuple FreedomBSP =
+  global LinkerScript:   Path
+  global Header:         Path
+  global InlineHeader:   Path
+  global PlatformHeader: Path
+  global Attributes:     FreedomMakeAttributes
 
-def addEntry (Pair memSubnode offsetInt) inDTSContents =
-  def offset = "0x{strbase 16 offsetInt}"
-  def subnodeOpt =
-    match "({memSubnode}@[0-9]+)".stringToRegExp
-      Pass regex =
-        def nodeRegex = regExpCat (`^\t\t`, `(?:L[a-zA-Z0-9_]+:\s)?`, regex, `\s{$`, Nil)
-        inDTSContents
-        | map nodeRegex.extract
-        | flatten
-        | head
-        | omap ("/soc/{_}")
-      Fail _ = None
+global def makeFreedomBSP coreDTS prefix =
+  def type = "rtl"
 
-  match subnodeOpt
-    Some subnode =
-      inDTSContents
-      | map (replace `^\tchosen\s{$` "\tchosen \{\n\t\tmetal,entry = <&\{{subnode}\} {offset}>;")
-    None = inDTSContents
+  # Generate the overlay
+  def designDTS =
+    makeDevicetreeOverlayGeneratorOptions coreDTS Nil type "{prefix}-design.dts"
+    | runDevicetreeOverlayGenerator
+    | getJobOutput
 
-def reWrap regex = match "({regex.regExpToString})".stringToRegExp
-  Pass r = r
-  Fail e = panic "Parenthesized string is an invalid Regular Expression: ({regex.regExpToString})"
+  # Create the DTB for the header generators
+  def designDTB = dtsTodtb designDTS (coreDTS, Nil) "{prefix}.dtb"
 
-def addSocSubnodeField subnodeRegex (Pair fieldName fieldValue) inDTSContents =
-  def socSplit = splitTo `\t(L[a-zA-Z0-9_]+:\s)?soc\s{$`.matches inDTSContents
-  def subnodeSplit =
-    def regex = regExpCat (`^\t{2}`, subnodeRegex.reWrap, `\s{$`, Nil)
-    splitTo regex.matches socSplit.getPairSecond
+  # Run the header generators
+  def header =
+    makeFreedomMetalHeaderGeneratorOptions designDTB "{prefix}.h"
+    | runFreedomMetalHeaderGenerator
 
-  if !subnodeSplit.getPairSecond.empty
-  then
-    socSplit.getPairFirst
-    ++ subnodeSplit.getPairFirst
-    ++ ("\t\t\t{fieldName} = {fieldValue};", subnodeSplit.getPairSecond)
-  else
-    inDTSContents
+  def platformHeader =
+    makeFreedomBareHeaderGeneratorOptions designDTB "{prefix}-platform.h"
+    | runFreedomBareHeaderGenerator
 
-def splitTo f l =  match l
-  Nil  = Pair Nil Nil
-  h, t if f h = Pair (h, Nil) t
-  h, t = match (splitTo f t)
-    Pair f s = Pair (h, f) s
+  # Run linker script generator
+  def linkerScript =
+    makeLdScriptGeneratorOptions designDTS (coreDTS, Nil) LDSCRIPT_DEFAULT "{prefix}.lds"
+    | runLdScriptGenerator
+    | getJobOutput
 
-def addChosenSubnode = addSubnode `(L[a-zA-Z0-9_]+:\s)?chosen`
+  # Create the settings for the Makefile
+  def attributesResult =
+    makeESDKSettingsGeneratorOptions designDTS (coreDTS, Nil) type "{prefix}.mk"
+    | runFreedomMakeAttributesGenerator
 
-def addSubnode parentNode node inDTSContents =
-  def split =
-    def firstSplit = splitTo (`^\t`, parentNode, `\s{$`, Nil).regExpCat.matches inDTSContents
-    def secondSplit = splitUntil `^\t};$`.matches firstSplit.getPairSecond
-    Pair (firstSplit.getPairFirst ++ secondSplit.getPairFirst) (secondSplit.getPairSecond)
-  split.getPairFirst ++ node ++ split.getPairSecond
-
-def addStdoutChosenFromAlias nodeName inDTSContents =
-  def parentNode = `(L[a-zA-Z0-9_]+:\s)soc`
-  def firstSplit = splitTo (`^\t`, parentNode, `\s{$`, Nil).regExpCat.matches inDTSContents
-  def secondSplit = splitUntil `\t\};$`.matches firstSplit.getPairSecond
-  def socContents = secondSplit.getPairFirst
-  def baudrate = 115200
-  match "({regExpToString nodeName.quote}@[0-9]+)".stringToRegExp
-    Fail e = inDTSContents
-    Pass nodeRegex =
-      def regex = regExpCat (`^\t\t(?:L[0-9]+:\s)?`, nodeRegex, `\s{$`, Nil)
-      def serialNodes = map regex.extract socContents | flatten
-      match serialNodes
-        serialNode, _ =
-          def stdChosen =
-            "\t\tstdout-path = \"/soc/{serialNode}:{str baudrate}\";", Nil
-          addChosenSubnode stdChosen inDTSContents
-        _ = inDTSContents
-
-def addChosenNode inDTSContents =
-  def parentNode = "/"
-  def firstSplit = splitTo (parentNode.quote, `\s{$`, Nil).regExpCat.matches inDTSContents
-  def secondSplit = splitUntil `.*{.*`.matches firstSplit.getPairSecond
-  def chosenNode = "\tchosen \{", "\t\};", Nil
-
-  firstSplit.getPairFirst
-  ++ secondSplit.getPairFirst
-  ++ chosenNode
-  ++ secondSplit.getPairSecond
-
-global target fixupDTS dts stdoutPath metalEntryPairOpt romNode ramNode =
-  def clkFrequency = 32500000
-  def prefix =
-    extract `(.*)\.dts` dts.getPathName
-    | head
-    | getOrElse dts.getPathName
-
-  match dts.read
-    Pass dtsContents =
-      dtsContents
-      | tokenize `\n`
-      | addChosenNode
-      | (omap addStdoutChosenFromAlias stdoutPath | getOrElse (_))
-      | (omap addEntry metalEntryPairOpt | getOrElse (_))
-      | (omap "metal,rom".addChosenRef romNode | getOrElse (_))
-      | (omap "metal,ram".addChosenRef ramNode | getOrElse (_))
-      | catWith "\n"
-      | write "{prefix}_fixed.dts"
-    fail = dts
+  match attributesResult
+    Pass attributes =
+      Pass (
+        FreedomBSP
+        linkerScript
+        header.getFreedomMetalHeaderGeneratorOutputsHeader
+        header.getFreedomMetalHeaderGeneratorOutputsInlineHeader
+        platformHeader
+        attributes
+      )
+    Fail err = Fail err
 
 global def generateMetalFromDts dts machineName outputDir =
   def prefix = "{outputDir}/{machineName}"
@@ -206,13 +158,7 @@ global def freedomMetalDUTProgramCompiler =
     def outputDir = programCompileOptions.getProgramCompileOptionsOutputDir
     def installDir = "build/freedom-metal/{dut.getDUTName}"
     def metalInstall =
-      fixupDTS
-      dut.getRocketChipDUTDTS
-      programCompileOptions.getProgramCompileOptionsStdoutPath
-      programCompileOptions.getProgramCompileOptionsEntry
-      programCompileOptions.getProgramCompileOptionsRom
-      programCompileOptions.getProgramCompileOptionsRam
-      | (generateMetalFromDts _ dut.getDUTName installDir)
+      generateMetalFromDts dut.getRocketChipDUTDTS dut.getDUTName installDir
     def gccProgramPlan =
       def outputFile = "{outputDir}/{programCompileOptions.getProgramCompileOptionsName}.elf"
       def newCFiles =

--- a/program/freedom-metal-program.wake
+++ b/program/freedom-metal-program.wake
@@ -31,12 +31,22 @@ tuple FreedomBSP =
   global PlatformHeader: Path
   global Attributes:     FreedomMakeAttributes
 
-global def makeFreedomBSP coreDTS type prefix =
+global def makeFreedomBSP coreDTS customOverlay type prefix =
   # Generate the overlay
+  def designDTSName = "{prefix}-design.dts"
   def designDTS =
-    makeDevicetreeOverlayGeneratorOptions coreDTS Nil type "{prefix}-design.dts"
-    | runDevicetreeOverlayGenerator
-    | getJobOutput
+    match customOverlay
+      Some overlay =
+        # Add coreDTS to the include list in the overlay
+        def coreFilename = extract `.*/(.*)` coreDTS.getPathName | head | getOrElse coreDTS.getPathName
+        def list = coreFilename, Nil ++ overlay.getDevicetreeCustomOverlayIncludes
+        overlay
+        | setDevicetreeCustomOverlayIncludes list
+        | (writeDevicetreeCustomOverlay designDTSName _)
+      None =
+        makeDevicetreeOverlayGeneratorOptions coreDTS Nil type designDTSName
+        | runDevicetreeOverlayGenerator
+        | getJobOutput
 
   # Create the DTB for the header generators
   def designDTB = dtsTodtb designDTS (coreDTS, Nil) "{prefix}.dtb"
@@ -73,9 +83,9 @@ global def makeFreedomBSP coreDTS type prefix =
       )
     Fail err = Fail err
 
-global def generateMetalFromDts dts machineName type outputDir =
+global def generateMetalFromDts dts machineName customOverlay type outputDir =
   def prefix = "{outputDir}/{machineName}"
-  def bsp = makeFreedomBSP dts type prefix
+  def bsp = makeFreedomBSP dts customOverlay type prefix
   def runMetalInstall bsp =
     def attributes = bsp.getFreedomBSPAttributes
     makeFreedomMetalConfigureOptions
@@ -159,7 +169,7 @@ global def freedomMetalDUTProgramCompiler =
       Some opt = opt
     def installDir = "build/freedom-metal/{dut.getDUTName}"
     def metalInstall =
-      generateMetalFromDts dut.getRocketChipDUTDTS dut.getDUTName type installDir
+      generateMetalFromDts dut.getRocketChipDUTDTS dut.getDUTName dut.getDUTCustomOverlay type installDir
     def gccProgramPlan =
       def outputFile = "{outputDir}/{programCompileOptions.getProgramCompileOptionsName}.elf"
       def newCFiles =

--- a/program/freedom-metal-program.wake
+++ b/program/freedom-metal-program.wake
@@ -31,9 +31,7 @@ tuple FreedomBSP =
   global PlatformHeader: Path
   global Attributes:     FreedomMakeAttributes
 
-global def makeFreedomBSP coreDTS prefix =
-  def type = "rtl"
-
+global def makeFreedomBSP coreDTS type prefix =
   # Generate the overlay
   def designDTS =
     makeDevicetreeOverlayGeneratorOptions coreDTS Nil type "{prefix}-design.dts"
@@ -75,9 +73,9 @@ global def makeFreedomBSP coreDTS prefix =
       )
     Fail err = Fail err
 
-global def generateMetalFromDts dts machineName outputDir =
+global def generateMetalFromDts dts machineName type outputDir =
   def prefix = "{outputDir}/{machineName}"
-  def bsp = makeFreedomBSP dts prefix
+  def bsp = makeFreedomBSP dts type prefix
   def runMetalInstall bsp =
     def attributes = bsp.getFreedomBSPAttributes
     makeFreedomMetalConfigureOptions
@@ -156,9 +154,12 @@ global def freedomMetalDUTProgramCompiler =
       | distinctBy (scmp _.getPathName _.getPathName)
 
     def outputDir = programCompileOptions.getProgramCompileOptionsOutputDir
+    def type = match dut.getDUTFPGABoardOpt
+      None     = "rtl"
+      Some opt = opt
     def installDir = "build/freedom-metal/{dut.getDUTName}"
     def metalInstall =
-      generateMetalFromDts dut.getRocketChipDUTDTS dut.getDUTName installDir
+      generateMetalFromDts dut.getRocketChipDUTDTS dut.getDUTName type installDir
     def gccProgramPlan =
       def outputFile = "{outputDir}/{programCompileOptions.getProgramCompileOptionsName}.elf"
       def newCFiles =

--- a/program/program.wake
+++ b/program/program.wake
@@ -36,10 +36,6 @@ tuple TestProgramPlan =
   global IncludeDirs: List String
   global Sources:     List Path
   global Filter:      DUTProgramCompiler => Boolean
-  global Entry:       Option (Pair String Integer)
-  global Rom:         Option String # name of the DTS node to set the 'metal,rom' chosen node to
-  global Ram:         Option String # name of the DTS node to set the 'metal,ram' chosen node to
-  global StdoutPath:  Option String # name of the DTS node to set the 'stdout-path' chosen node to
 
 global def makeTestProgramPlan name cfiles =
   TestProgramPlan
@@ -50,10 +46,6 @@ global def makeTestProgramPlan name cfiles =
   Nil       # IncludeDirs: List String
   Nil       # Sources:     List Path
   (\_ True) # Filter:      DUTProgramCompiler => Boolean
-  None
-  None
-  None
-  (Some "simSerial")
 
 global def testProgramPlanToProgramCompileOptions plan outputDir =
   def name        = plan.getTestProgramPlanName
@@ -63,10 +55,6 @@ global def testProgramPlanToProgramCompileOptions plan outputDir =
   def includeDirs = plan.getTestProgramPlanIncludeDirs
   def sources     = plan.getTestProgramPlanSources
   def filter      = plan.getTestProgramPlanFilter
-  def entry       = plan.getTestProgramPlanEntry
-  def rom         = plan.getTestProgramPlanRom
-  def ram         = plan.getTestProgramPlanRam
-  def stdoutPath  = plan.getTestProgramPlanStdoutPath
 
   ProgramCompileOptions
   name
@@ -77,10 +65,6 @@ global def testProgramPlanToProgramCompileOptions plan outputDir =
   sources
   outputDir
   filter
-  entry
-  rom
-  ram
-  stdoutPath
 
 global def testProgramPlanToGCCProgramPlan outputFile plan =
   testProgramPlanToProgramCompileOptions plan "{outputFile}/..".simplify
@@ -96,22 +80,14 @@ tuple ProgramCompileOptions =
   global Sources:     List Path
   global OutputDir:   String
   global Filter:      DUTProgramCompiler => Boolean
-  global Entry:       Option (Pair String Integer)
-  global Rom:         Option String # name of the DTS node to set the 'metal,rom' chosen node to
-  global Ram:         Option String # name of the DTS node to set the 'metal,ram' chosen node to
-  global StdoutPath:  Option String # name of the DTS node to set the 'stdout-path' chosen node to
 
 global def makeProgramCompileOptions name cflags cfiles outputDir =
   def asFlags     = Nil
   def includeDirs = Nil
   def sources     = Nil
   def filter      = (\_ True)
-  def entry = None
-  def rom = None
-  def ram = None
-  def stdoutPath = None
 
-  ProgramCompileOptions name cflags asFlags cfiles includeDirs sources outputDir filter entry rom ram stdoutPath
+  ProgramCompileOptions name cflags asFlags cfiles includeDirs sources outputDir filter
 
 global def programCompileOptionsToGCCProgramPlan outputFile plan =
   def name        = plan.getProgramCompileOptionsName

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "feee9ff08bd6ed29fe42a59cfe5eea74ba44612f",
+        "commit": "da652642f7b1f88af7a1feaab82a81e534b2b206",
         "name": "freedom-metal",
         "source": "git@github.com:sifive/freedom-metal.git"
     },

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -25,17 +25,17 @@
         "source": "git@github.com:sifive/scribble-testsocket-sifive.git"
     },
     {
-        "commit": "ce94cba8088703f08c4373c5b3c527cdadb5ad76",
+        "commit": "4e3d67ca1ebac7fa9956558f03d964bded1f5653",
         "name": "devicetree-overlay-generator",
         "source": "git@github.com:sifive/devicetree-overlay-generator.git"
     },
     {
-        "commit": "f9b4db041c8a83f7bc42d264e408be5c2594c0bd",
+        "commit": "cff1b713ac789bea21bcb794c6e376dd7d8ca8dc",
         "name": "esdk-settings-generator",
         "source": "git@github.com:sifive/esdk-settings-generator.git"
     },
     {
-        "commit": "6ae727e7c050f5391767ec6b127e7af7c25a6b56",
+        "commit": "c3c867cc55aaeaaeee3ca2c49092ffd87aa9b01c",
         "name": "ldscript-generator",
         "source": "git@github.com:sifive/ldscript-generator.git"
     }

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -5,7 +5,7 @@
         "source": "git@github.com:sifive/freedom-metal.git"
     },
     {
-        "commit": "89e427e15a403add4eb837f1466f0be9078049f0",
+        "commit": "38aa006c23057b2c76b0f1b9380709ac368e9f85",
         "name": "freedom-devicetree-tools",
         "source": "git@github.com:sifive/freedom-devicetree-tools.git"
     },
@@ -23,5 +23,20 @@
         "commit": "c675ef819c022a4871bc7a4db8e40018dd188ea2",
         "name": "scribble-testsocket-sifive",
         "source": "git@github.com:sifive/scribble-testsocket-sifive.git"
+    },
+    {
+        "commit": "ce94cba8088703f08c4373c5b3c527cdadb5ad76",
+        "name": "devicetree-overlay-generator",
+        "source": "git@github.com:sifive/devicetree-overlay-generator.git"
+    },
+    {
+        "commit": "f9b4db041c8a83f7bc42d264e408be5c2594c0bd",
+        "name": "esdk-settings-generator",
+        "source": "git@github.com:sifive/esdk-settings-generator.git"
+    },
+    {
+        "commit": "6ae727e7c050f5391767ec6b127e7af7c25a6b56",
+        "name": "ldscript-generator",
+        "source": "git@github.com:sifive/ldscript-generator.git"
     }
 ]


### PR DESCRIPTION
Keeping this PR as a draft until the various dependencies of this PR get rolled up into their respective master branches.

In the meantime, this is my take on converting this repository from using the freedom-devicetree-tools based flow to the new python tools. Namely, instead of doing a "fixup", this uses the [devicetree-overlay-generator](https://github.com/sifive/devicetree-overlay-generator) to create a new top-level Devicetree. This overlay generator allows us to dramatically simplify the following tools (especially the linker script generator).

I haven't yet tried to run the new wake scripts (I'm not sure how to drive this repository) but the wake type-checks so it solves my problem at least.

These changes are necessary because we're [replacing the freedom-devicetree-tools implementation of most of the tools the old wake rules used](https://github.com/sifive/freedom-devicetree-tools/pull/204).