### PR TITLE
Fix DTSJSON Path when base file names are overridden.

### DIFF
--- a/dut/rocket-chip-dut.wake
+++ b/dut/rocket-chip-dut.wake
@@ -56,6 +56,10 @@ global def getRocketChipDUTDTS         = getDUTDTS
 
 def getTestharnessTopModule testharness = (tokenize `\.` testharness).reverse.head
 
+def getWhenFailFn fn = match _
+  Pass a = a
+  Fail f = fn f
+
 global def rocketChipDUTMaker dutPlan userArgs =
   def rocketOutputs = doRocketGenerate dutPlan userArgs
   def firrtlOutputs = doFirrtlCompile dutPlan userArgs rocketOutputs
@@ -72,20 +76,31 @@ global def rocketChipDUTMaker dutPlan userArgs =
   def allOutputs = rocketOutputs.getRocketChipGeneratorOutputsAllOutputs
   def topModuleOpt = dutPlan.getRocketChipDUTPlanTestharness.getTestharnessTopModule
   def dts = rocketOutputs.getRocketChipGeneratorOutputsDTS
+
+  # TODO: This should be something that is captured by
+  # RocketChipGeneratorOutputs in rocket-chip.git, since only the Wake rules in
+  # that repo can know what the final output filenames look like.
+  # This can be replaced once we actually add that in rocket-chip.git.
   def dtsJSON =
-    def fileName =
+    def fileNameOpt =
       rocketOutputs
       | getRocketChipGeneratorOutputsInputOptions
-      | getRocketChipGeneratorOptionsConfigNames
-      | catWith "_"
-      | ("_root_.{_}.json")
-    def fileRegex = regExpCat (`([^/]*/)*`, fileName.quote, Nil)
+      | getRocketChipGeneratorOptionsBaseFileName
+      | omap ("{_}.json")
 
-    rocketOutputs
-    | getRocketChipGeneratorOutputsAllOutputs
-    | find (matches fileRegex _.getPathName)
-    | omap getPairFirst
-    | getOrElse "{fileName} file not found".makeError.makeBadPath
+    def getDTSJSONForFileName fileName =
+      def fileRegex = regExpCat (`([^/]*/)*`, fileName.quote, Nil)
+
+      rocketOutputs
+      | getRocketChipGeneratorOutputsAllOutputs
+      | find (matches fileRegex _.getPathName)
+      | omap getPairFirst
+      | getOrFail "{fileName} file not found".makeError
+
+    fileNameOpt
+    | getOrFail "dtsJSON not available if outputBaseName not explicitly passed to rocket-chip Generator.scala.".makeError
+    | rmapPass getDTSJSONForFileName
+    | getWhenFailFn (_.makeBadPath)
 
   match objectModelResult topModuleOpt
     (Pass objectModel) (Some topModule) =

--- a/dut/rocket-chip-dut.wake
+++ b/dut/rocket-chip-dut.wake
@@ -56,10 +56,6 @@ global def getRocketChipDUTDTS         = getDUTDTS
 
 def getTestharnessTopModule testharness = (tokenize `\.` testharness).reverse.head
 
-def getWhenFailFn fn = match _
-  Pass a = a
-  Fail f = fn f
-
 global def rocketChipDUTMaker dutPlan userArgs =
   def rocketOutputs = doRocketGenerate dutPlan userArgs
   def firrtlOutputs = doFirrtlCompile dutPlan userArgs rocketOutputs
@@ -82,25 +78,36 @@ global def rocketChipDUTMaker dutPlan userArgs =
   # that repo can know what the final output filenames look like.
   # This can be replaced once we actually add that in rocket-chip.git.
   def dtsJSON =
-    def fileNameOpt =
+    # getFileName: RocketChipGeneratorOutputs => Result String String
+    def getFileName rocketOutputs =
       rocketOutputs
       | getRocketChipGeneratorOutputsInputOptions
       | getRocketChipGeneratorOptionsBaseFileName
       | omap ("{_}.json")
+      | getOrFail "dtsJSON not available if outputBaseName not explicitly passed to rocket-chip Generator.scala.".makeError
 
-    def getDTSJSONForFileName fileName =
-      def fileRegex = regExpCat (`([^/]*/)*`, fileName.quote, Nil)
-
+    # getOrFailOutputs: RocketChipGeneratorOutputs => Result (List Path) Error
+    # If any output is a BadPath, then return Fail with the first failed path.
+    # Otherwise return Pass with the full list of paths.
+    def getOrFailOutputs rocketOutputs =
       rocketOutputs
       | getRocketChipGeneratorOutputsAllOutputs
+      | findFailFn getPathResult
+
+    # findDTSJSONPath: String => List Path => Path
+    # Find the output Path corresponding to the filename, returning BadPath if
+    # not fonud.
+    def findDTSJSONPath fileName outputs =
+      def fileRegex = regExpCat (`([^/]*/)*`, fileName.quote, Nil)
+      outputs
       | find (matches fileRegex _.getPathName)
       | omap getPairFirst
-      | getOrFail "{fileName} file not found".makeError
+      | getOrElse "{fileName} file not found".makeError.makeBadPath
 
-    fileNameOpt
-    | getOrFail "dtsJSON not available if outputBaseName not explicitly passed to rocket-chip Generator.scala.".makeError
-    | rmapPass getDTSJSONForFileName
-    | getWhenFailFn (_.makeBadPath)
+    match (Pair (getFileName rocketOutputs) (getOrFailOutputs rocketOutputs))
+      Pair (Fail err) _ = err.makeBadPath
+      Pair _ (Fail err) = err.makeBadPath
+      Pair (Pass fileName) (Pass outputs) = findDTSJSONPath fileName outputs
 
   match objectModelResult topModuleOpt
     (Pass objectModel) (Some topModule) =


### PR DESCRIPTION
As @davidmlw mentioned in https://github.com/sifive/api-generator-sifive/commit/e238d26e0dcc9f8f36edb9dc4fb2ae18cdd3667f#commitcomment-37789577, the DTS JSON path is incorrect if the `RocketChipGeneratorOptions` `BaseFileName` option is set, since the DTS JSON file path has a hardcoded `_root_` that is only used when no option is set.

This fixes the issue in api-generator-sifive.git by deriving the base file name from the BaseFileName. I wrote the logic so that instead of trying a default value when that `BaseFileName` is not set, it just returns a `BadPath`. I think this is somewhat safe to do because in this file, we always set `BaseFileName`, so even though the `BaseFileName` is an option, we can be more confident that it is always be set here.

The ideal solution would be to actually provide the `dtsJSON` path from rocket-chip.git's Wake file, since that's where it has the logic for defaulting to `_root_` in the first place. However, I opted to not do that since that would require making an update in rocket-chip and updating api-generator-sifive to point to it, which does not seem to just work out of the box, because we have no continuous integration set up on this repository.

If I have time, I'll add the `dtsJSON` option to rocket-chip as well so that we can later opportunistically remove the code path I have added here.

Tested locally on a configuration that was previously failing to find the DTS JSON and confirmed that it is in fact being detected now.