### PR TITLE
named-args.wake: Privatize named arg functions

### DIFF
--- a/utils/named-arg.wake
+++ b/utils/named-arg.wake
@@ -5,35 +5,35 @@ global data NamedArg =
   NamedArgString  String String
   NamedArgPath    String Path
 
-global def getNamedArgName = match _
+def getNamedArgName = match _
   NamedArg        n   = n
   NamedArgInteger n _ = n
   NamedArgDouble  n _ = n
   NamedArgString  n _ = n
   NamedArgPath    n _ = n
 
-global def getNamedArgValue dir = match _
+def getNamedArgValue dir = match _
   NamedArg        _   = None
   NamedArgInteger _ i = Some (str i)
   NamedArgDouble  _ d = Some (dstr d)
   NamedArgString  _ s = Some (s)
   NamedArgPath    _ p = Some (relative dir p.getPathName)
 
-global def namedArgToString dir separator namedArg =
+def namedArgToString dir separator namedArg =
   def name = namedArg.getNamedArgName
   def valueOpt = getNamedArgValue dir namedArg
   match valueOpt
     None       = name
     Some value = "{name}{separator}{value}"
 
-global def namedArgToListString dir namedArg =
+def namedArgToListString dir namedArg =
   def name = namedArg.getNamedArgName
   def valueOpt = getNamedArgValue dir namedArg
   match valueOpt
     None       = name, Nil
     Some value = name, value, Nil
 
-global def namedArgValueEquals = match _ _
+def namedArgValueEquals = match _ _
   (NamedArg        _   ) (NamedArg        _   ) = True
   (NamedArgInteger _ i1) (NamedArgInteger _ i2) = i1 == i2
   (NamedArgDouble  _ d1) (NamedArgDouble  _ d2) = d1 ==. d2
@@ -41,7 +41,7 @@ global def namedArgValueEquals = match _ _
   (NamedArgPath    _ p1) (NamedArgPath    _ p2) = p1.getPathName ==~ p2.getPathName
   _ _ = False
 
-global def namedArgEquals a1 a2 =
+def namedArgEquals a1 a2 =
   a1.getNamedArgName ==~ a2.getNamedArgName
   && namedArgValueEquals a1 a2
 

--- a/utils/named-arg.wake
+++ b/utils/named-arg.wake
@@ -1,3 +1,10 @@
+# A named argument for a command-line command.
+#
+# This represents pairs of name-value argument pairs, e.g. --verbosity 2 would
+# have a key of "--verbosity" and a value of 2.
+#
+# Note that this also represents unnamed arguments with the NamedArg constructor
+# that does not take a second argument.
 global data NamedArg =
   NamedArg        String
   NamedArgInteger String Integer
@@ -33,22 +40,25 @@ def namedArgToListString dir namedArg =
     None       = name, Nil
     Some value = name, value, Nil
 
-def namedArgValueEquals = match _ _
-  (NamedArg        _   ) (NamedArg        _   ) = True
-  (NamedArgInteger _ i1) (NamedArgInteger _ i2) = i1 == i2
-  (NamedArgDouble  _ d1) (NamedArgDouble  _ d2) = d1 ==. d2
-  (NamedArgString  _ s1) (NamedArgString  _ s2) = s1 ==~ s2
-  (NamedArgPath    _ p1) (NamedArgPath    _ p2) = p1.getPathName ==~ p2.getPathName
-  _ _ = False
-
-def namedArgEquals a1 a2 =
-  a1.getNamedArgName ==~ a2.getNamedArgName
-  && namedArgValueEquals a1 a2
-
+# Render a list of NamedArgs to a list of command-line argument strings.
+#
+# Creates a separate list item for each component of the NamedArg pairs,
+# resolving any Paths to strings containing paths relative to `dir`.
+#
+# namedArgsToListString: (dir: String) => (namedArgs: List NamedArg) => List String
 global def namedArgsToListString dir namedArgs =
   namedArgs
   | map (namedArgToListString dir _)
   | flatten
 
+# Render a list of NamedArgs to a list of command-line argument strings.
+#
+# (dir: String) => Combines with NamedArgPath to construct a relative path.
+#   Generally should be set to the the current working directory of the command.
+# (prefix: String) => A prefix to use with each argument name, such as "--"
+# (separator: String) => A string that separates the name from the argument,
+#   such as "="
+# (namedArgs: List NamedArg) => List of `NamedArgs`
+# List String
 global def namedArgsToCmdline dir prefix separator namedArgs =
   map ("{prefix}{namedArgToString dir separator _}") namedArgs


### PR DESCRIPTION
Unless if there's a strong reason to leave these as global/public, I've gone ahead and made most of these functions private. I was having a bit of difficulty understanding the semantics of the `dir` argument to `namedArgsToCmdline`, and it was a little bit difficult for me to understand, since I had to chase the call stack following the `dir` argument all the way to `getNamedArgValue`, and then "pop back out" the stack to remember what I was doing.

I added documentation, but rather than documenting all of these functions that take in the `dir` argument, I thought it might be a nicer API to only force callers of `namedArgsToCmdline` to have to understand what `dir` means rather than documenting every single one of these functions.

I did a quick check across several of our internal repositories and I do not see most of these functions being called directly, so it should be safe to make most of them private.

---

On a side note, it feels that the abstraction that we were going for here is a bit off center. I know it'll require a lot of work to migrate, especially given that repositories like https://github.com/sifive/block-pio-sifive contribute their own `NamedArg` instances, but I was wondering if you think it would be better to eventually replace all this with a simpler abstraction that does not attempt to provide an abstraction for choosing between `--` and `+` as the prefix, `=` as an operator, or requiring that any non-string arguments must be paired with a "name". For the latter, I think we've run into trouble when we wanted to pass in a `Path` without having an accompanying name. In addition, we've also run into trouble when we want to mix and match `--` and `+` prefixes, since _both_ are valid to pass into Verilog simulation tools.