### PR TITLE
Handle address blocks in software headers and drivers

### DIFF
--- a/scripts/generate_header.py
+++ b/scripts/generate_header.py
@@ -100,7 +100,7 @@ class DeviceBase:
     base_interrupt: t.Optional[int]
     base_address: int
     interrupts: t.List[Interrupt]
-    registers: t.List[RegisterField]
+    register_fields: t.List[RegisterField]
 
 ###
 # templates
@@ -168,7 +168,7 @@ def generate_offsets(device_name: str, dev_list: t.List[DeviceBase]) -> str:
     capitalized_device = device_name.upper()
     if dev_list:
         # only need to check the first device
-        for a_reg in dev_list[0].registers:
+        for a_reg in dev_list[0].register_fields:
             if a_reg.name == 'reserved':
                 continue
             name = a_reg.name.upper().strip().replace(" ", "")
@@ -297,14 +297,14 @@ def find_interrupts(object_model: JSONType, device: str) \
     return rv
 
 
-def find_registers(object_model: JSONType) -> t.List[RegisterField]:
+def find_register_fields(object_model: JSONType) -> t.List[RegisterField]:
     """
     given a parsed device, return the register fields for the device
 
     :param object_model: a device parsed from the object model
     :return: a list of register fields
     """
-    reglist: t.List[RegisterField] = []
+    fields: t.List[RegisterField] = []
     for mr in object_model['memoryRegions']:
         # get base address for each memory region
         if len(mr['addressSets']) != 1:
@@ -322,9 +322,9 @@ def find_registers(object_model: JSONType) -> t.List[RegisterField]:
                                             r_width,
                                             r_group)
 
-            reglist.append(r)
+            fields.append(r)
 
-    return reglist
+    return fields
 
 
 def find_devices(object_model: JSONType,
@@ -406,7 +406,7 @@ def main() -> int:
     devices_om = find_devices(object_model, device)
 
     for index, dev_om in devices_om:
-        reglist = find_registers(dev_om)
+        fields = find_register_fields(dev_om)
         intlist = find_interrupts(dev_om, device)
         base_int = min((i.number for i in intlist), default=None)
         base_address = dev_om['memoryRegions'][0]['addressSets'][0]['base']
@@ -416,7 +416,7 @@ def main() -> int:
                                   base_interrupt=base_int,
                                   base_address=base_address,
                                   interrupts=intlist,
-                                  registers=reglist))
+                                  register_fields=fields))
 
     base_hdr_path = bsp_dir_path / f'bsp_{device}'
     base_hdr_path.mkdir(exist_ok=True, parents=True)

--- a/scripts/generate_header.py
+++ b/scripts/generate_header.py
@@ -189,21 +189,28 @@ def generate_offsets(device_name: str, dev_list: t.List[DeviceBase]) -> str:
             offset = a_reg.offset
             width = a_reg.width
 
+            # For legacy reasons, emit both a version of these macros with
+            # and without the address block name.
             infix = ''
-            if addressBlock:
-                infix += f'_{addressBlock}'
             if group:
-                infix += f'_{group}'
+                infix = f'_{group}'
+            legacy_prefix = f'{capitalized_device}_REGISTER{infix}_{name}'
 
-            prefix = f'{capitalized_device}_REGISTER{infix}_{name}'
+            prefixes = [legacy_prefix]
 
-            NAME_COLLISION_DICT[prefix] += 1
-            macro_line =  f'#define {prefix} {offset}\n'
-            macro_line += f'#define {prefix}_BYTE {offset >> 3}\n'
-            macro_line += f'#define {prefix}_BIT {offset & 0x7}\n'
-            macro_line += f'#define {prefix}_WIDTH {width}\n'
+            if addressBlock:
+                infix = f'_{addressBlock}'
+                if group:
+                    infix += f'_{group}'
+                prefixes.append(f'{capitalized_device}_REGISTER{infix}_{name}')
+            for prefix in prefixes:
+                NAME_COLLISION_DICT[prefix] += 1
+                macro_line =  f'#define {prefix} {offset}\n'
+                macro_line += f'#define {prefix}_BYTE {offset >> 3}\n'
+                macro_line += f'#define {prefix}_BIT {offset & 0x7}\n'
+                macro_line += f'#define {prefix}_WIDTH {width}\n'
 
-            rv.append(macro_line)
+                rv.append(macro_line)
 
     return '\n'.join(rv)
 


### PR DESCRIPTION
One component of https://github.com/sifive/duh-scala/issues/79.

This updates both the `generate_headers.py` and `generate_drivers.py` scripts for the IP onboarding workflow to handle address blocks. My goals were to 1) seamlessly support the notion of the address blocks by including the address block name in the generated C macros and 2) preserve backwards compatibility for existing IP blocks.

What was a little bit challenging is that although `generate_headers.py` derives its information from the Object Model, `generate_drivers.py` derives its information directly from DUH. Although I could automatically detect the address block scenario in the former by checking whether the Object Model actually contains any references to address blocks, the latter was more challenging, since DUH has always had mandatory address blocks for describing registers.

For the best backwards and forwards compatibility, I went with the following rules:

- `generate_headers.py` - Always emit the old-style macros that didn't have the address blocks, but in addition emit the new-style macros if the address block property is present in the Object Model.
- `generate_drivers.py` -  If there are multiple address blocks, always emit the driver with the addresss block name in the macro; otherwise emit the old-style macro. This is overridable with the `--always-include-address-block-in-macros` command-line argument.

The other change that I made was to update `generate_headers.py` to also emit the relative base address of each address block as a set of standalone macros, in case if someone wants to handwrite a driver that references the address block base address. This is probably useful in the case where the address block doesn't actually contain registers, such as when it acts as a memory-like region rather than memory-mapped control registers.

---

I tested this by hacking up the block-pio-sifive flow to add in a second address block, as well as faking out the Object Model with a hand-written Object Model in which I added the OMAddressBlock and other information.

I attempted to test this both with and without my hacked up changes, to make sure that I did indeed preserve backwards compatibility, but I think it'll be hard to know if this works for real until duh-scala is updated to emit the OMAddressBlock information.