### PR TITLE
Add 'openjdk/java/1.8.0' resource string to java invocations

### DIFF
--- a/dut/rocket-chip-dut.wake
+++ b/dut/rocket-chip-dut.wake
@@ -191,7 +191,7 @@ target doFirrtlCompile dutPlan userArgs rocketOutputs =
     def logLevel = "info"
     def fct = "-fct", "{catWith "," customFirrtlTransforms}", Nil
     def classpath = jars | map getPathName | catWith ":"
-    which "java", "-Xmx2G", "-Xss8M", "-cp", classpath, main,
+    "java", "-Xmx2G", "-Xss8M", "-cp", classpath, main,
     "-i",             firrtlFile.getPathName,
     "-tn",            topName,
     "-td",            verilogDir.getPathName,
@@ -206,6 +206,7 @@ target doFirrtlCompile dutPlan userArgs rocketOutputs =
   def inputs = verilogDir, firrtlFile, annoFile, cmdlineAnnoFile, jars
   def firrtlOutputs =
     makePlan cmdline inputs
+    | setPlanResources ("openjdk/java/1.8.0", Nil)
     | runJob
     | getJobOutputs
   def getFile name = filter (_.getPathName ==~ name) firrtlOutputs | head


### PR DESCRIPTION
Add a resource string (via `setPlanResources`) for java invocations.

A wake runner can use this to resolve a shell `PATH` and `JAVA_HOME` to allow setting different installation locations for java.
If no wake runner is available, wake will fallback to the current default `PATH=/usr/bin:/bin`