### PR TITLE
generate_header: Do not assume all OMMemoryRegions have registers.

### DIFF
--- a/scripts/generate_header.py
+++ b/scripts/generate_header.py
@@ -312,9 +312,15 @@ def find_registers(object_model: JSONType) -> t.List[RegisterField]:
                             "region")
 
         # get regs for every memory region
+        if not mr.get('registerMap'):
+            continue
+
         for aReg in mr['registerMap']['registerFields']:
+            r_group = aReg['description'].get('group')
+            if not r_group:
+                continue
+
             r_name = aReg['description']['name']
-            r_group = aReg['description']['group']
             r_offset = aReg['bitRange']['base']
             r_width = aReg['bitRange']['size']
             r = RegisterField.make_register(r_name,


### PR DESCRIPTION
There are two scenarios where the current code fails:

1. When an OMMemoryRegion has no OMRegisterMap
2. When an OMMemoryRegion has an OMRegisterMap, but not all OMRegFields contain
a RegFieldDesc group, which is equivalent to a "register".

This PR adds conditional logic to generate_header.py to 1) not assume that an OMMemoryRegion has a registerMap property, and to 2) not assume that all OMRegFields have an associated group.