### PR TITLE
api for synth only fpga ci target

### DIFF
--- a/fpga/mcs.wake
+++ b/fpga/mcs.wake
@@ -19,6 +19,61 @@ def vc707migHook =
   def addResources = "vivado/vc7071gmig/1.0"
   makeBlackBoxHook name addResources
 
+global target fpgaSynthOnly plan =
+  def name = plan.getBitstreamPlanName
+  def resources = plan.getBitstreamPlanResources
+  def outputDir = plan.getBitstreamPlanOutputDir
+  def designTopModule = plan.getBitstreamPlanTopModule
+  def vendor = plan.getBitstreamPlanVendor
+  def board = plan.getBitstreamPlanBoard
+  def visibleFiles = plan.getBitstreamPlanVisibleFiles
+
+  def vivadoSynth =
+    def sourceTcl = source "fpga-shells/{vendor}/common/tcl/synth-only.tcl"
+    def tclFiles = plan.getBitstreamPlanTclFiles
+    def vsrcs = plan.getBitstreamPlanVsrcs
+    def runDir = outputDir
+
+    def ffile =
+      map (relative runDir _.getPathName) vsrcs
+      | catWith "\n"
+      | write "{runDir}/verilog.F"
+
+    def tclArgs =
+      def tclsString =
+        tclFiles
+        | map (relative runDir _.getPathName)
+        | ("{catWith "  " _}")
+      "-top-module",     designTopModule,
+      "-board",          board,
+      "-F",              (relative runDir ffile.getPathName),
+      "-ip-vivado-tcls", tclsString,
+      "-env-var-srcs",   "WAKE_IP_RESOURCE_FILES",
+      Nil
+
+    def fnOutputs _ = files outputDir `.*\.bit`
+
+    def tclSupportFiles =
+      (sources "fpga-shells/{vendor}/{board}/tcl" `.*\.tcl`)
+      ++ (sources "fpga-shells/{vendor}/common/tcl/" `.*\.tcl`)
+      ++ (sources "fpga-shells/{vendor}/{board}/constraints/" `.*\.xdc`)
+
+    def allVisibleFiles =
+      (outputDir.mkdir, ffile, Nil)
+      ++ visibleFiles
+      ++ tclSupportFiles
+      ++ vsrcs
+      ++ tclFiles
+
+    makeVivadoPlan sourceTcl outputDir
+    | setVivadoPlanTclArgs tclArgs
+    | setVivadoPlanResources resources
+    | setVivadoPlanFnOutputs fnOutputs
+    | setVivadoPlanVisibleFiles allVisibleFiles
+    | runVivado
+
+  vivadoSynth
+
 global target makeBitstream plan =
   def name = plan.getBitstreamPlanName
   def resources = plan.getBitstreamPlanResources

--- a/fpga/mcs.wake
+++ b/fpga/mcs.wake
@@ -20,117 +20,66 @@ def vc707migHook =
   makeBlackBoxHook name addResources
 
 global target fpgaSynthOnly plan =
-  def name = plan.getBitstreamPlanName
-  def resources = plan.getBitstreamPlanResources
-  def outputDir = plan.getBitstreamPlanOutputDir
-  def designTopModule = plan.getBitstreamPlanTopModule
-  def vendor = plan.getBitstreamPlanVendor
-  def board = plan.getBitstreamPlanBoard
-  def visibleFiles = plan.getBitstreamPlanVisibleFiles
-
-  def vivadoSynth =
-    def sourceTcl = source "fpga-shells/{vendor}/common/tcl/synth-only.tcl"
-    def tclFiles = plan.getBitstreamPlanTclFiles
-    def vsrcs = plan.getBitstreamPlanVsrcs
-    def runDir = outputDir
-
-    def ffile =
-      map (relative runDir _.getPathName) vsrcs
-      | catWith "\n"
-      | write "{runDir}/verilog.F"
-
-    def tclArgs =
-      def tclsString =
-        tclFiles
-        | map (relative runDir _.getPathName)
-        | ("{catWith "  " _}")
-      "-top-module",     designTopModule,
-      "-board",          board,
-      "-F",              (relative runDir ffile.getPathName),
-      "-ip-vivado-tcls", tclsString,
-      "-env-var-srcs",   "WAKE_IP_RESOURCE_FILES",
-      Nil
-
-    def fnOutputs _ = files outputDir `.*\.bit`
-
-    def tclSupportFiles =
-      (sources "fpga-shells/{vendor}/{board}/tcl" `.*\.tcl`)
-      ++ (sources "fpga-shells/{vendor}/common/tcl/" `.*\.tcl`)
-      ++ (sources "fpga-shells/{vendor}/{board}/constraints/" `.*\.xdc`)
-
-    def allVisibleFiles =
-      (outputDir.mkdir, ffile, Nil)
-      ++ visibleFiles
-      ++ tclSupportFiles
-      ++ vsrcs
-      ++ tclFiles
-
-    makeVivadoPlan sourceTcl outputDir
-    | setVivadoPlanTclArgs tclArgs
-    | setVivadoPlanResources resources
-    | setVivadoPlanFnOutputs fnOutputs
-    | setVivadoPlanVisibleFiles allVisibleFiles
-    | runVivado
-
-  vivadoSynth
+    runVivadoWithPlan plan "fpga-shells/xilinx/common/tcl/synth-only.tcl"
 
 global target makeBitstream plan =
-  def name = plan.getBitstreamPlanName
-  def resources = plan.getBitstreamPlanResources
-  def outputDir = plan.getBitstreamPlanOutputDir
-  def designTopModule = plan.getBitstreamPlanTopModule
-  def vendor = plan.getBitstreamPlanVendor
-  def board = plan.getBitstreamPlanBoard
-  def visibleFiles = plan.getBitstreamPlanVisibleFiles
-
-  def vivadoBitstream =
-    def sourceTcl = source "fpga-shells/{vendor}/common/tcl/vivado.tcl"
-    def tclFiles = plan.getBitstreamPlanTclFiles
-    def vsrcs = plan.getBitstreamPlanVsrcs
-    def runDir = outputDir
-
-    def ffile =
-      map (relative runDir _.getPathName) vsrcs
-      | catWith "\n"
-      | write "{runDir}/verilog.F"
-
-    def tclArgs =
-      def tclsString =
-        tclFiles
-        | map (relative runDir _.getPathName)
-        | ("{catWith "  " _}")
-      "-top-module",     designTopModule,
-      "-board",          board,
-      "-F",              (relative runDir ffile.getPathName),
-      "-ip-vivado-tcls", tclsString,
-      "-env-var-srcs",   "WAKE_IP_RESOURCE_FILES",
-      Nil
-
-    def fnOutputs _ = files outputDir `.*\.bit`
-
-    def tclSupportFiles =
-      (sources "fpga-shells/{vendor}/{board}/tcl" `.*\.tcl`)
-      ++ (sources "fpga-shells/{vendor}/common/tcl/" `.*\.tcl`)
-      ++ (sources "fpga-shells/{vendor}/{board}/constraints/" `.*\.xdc`)
-
-    def allVisibleFiles =
-      (outputDir.mkdir, ffile, Nil)
-      ++ visibleFiles
-      ++ tclSupportFiles
-      ++ vsrcs
-      ++ tclFiles
-
-    makeVivadoPlan sourceTcl outputDir
-    | setVivadoPlanTclArgs tclArgs
-    | setVivadoPlanResources resources
-    | setVivadoPlanFnOutputs fnOutputs
-    | setVivadoPlanVisibleFiles allVisibleFiles
-    | runVivado
-
+  def vivadoBitstream = runVivadoWithPlan plan  "fpga-shells/xilinx/common/tcl/vivado.tcl"
   BitstreamOutputs
   vivadoBitstream.getVivadoOutputBitstream
   vivadoBitstream.getVivadoOutputAllOutputs
   plan
+
+global target runVivadoWithPlan plan tclFile =
+  def name = plan.getBitstreamPlanName
+  def resources = plan.getBitstreamPlanResources
+  def outputDir = plan.getBitstreamPlanOutputDir
+  def designTopModule = plan.getBitstreamPlanTopModule
+  def vendor = plan.getBitstreamPlanVendor
+  def board = plan.getBitstreamPlanBoard
+  def visibleFiles = plan.getBitstreamPlanVisibleFiles
+
+  def sourceTcl = source tclFile
+  def tclFiles = plan.getBitstreamPlanTclFiles
+  def vsrcs = plan.getBitstreamPlanVsrcs
+  def runDir = outputDir
+
+  def ffile =
+    map (relative runDir _.getPathName) vsrcs
+    | catWith "\n"
+    | write "{runDir}/verilog.F"
+
+  def tclArgs =
+    def tclsString =
+      tclFiles
+      | map (relative runDir _.getPathName)
+      | ("{catWith "  " _}")
+    "-top-module",     designTopModule,
+    "-board",          board,
+    "-F",              (relative runDir ffile.getPathName),
+    "-ip-vivado-tcls", tclsString,
+    "-env-var-srcs",   "WAKE_IP_RESOURCE_FILES",
+    Nil
+
+  def fnOutputs _ = files outputDir `.*\.bit`
+
+  def tclSupportFiles =
+    (sources "fpga-shells/{vendor}/{board}/tcl" `.*\.tcl`)
+    ++ (sources "fpga-shells/{vendor}/common/tcl/" `.*\.tcl`)
+    ++ (sources "fpga-shells/{vendor}/{board}/constraints/" `.*\.xdc`)
+
+  def allVisibleFiles =
+    (outputDir.mkdir, ffile, Nil)
+    ++ visibleFiles
+    ++ tclSupportFiles
+    ++ vsrcs
+    ++ tclFiles
+
+  makeVivadoPlan sourceTcl outputDir
+  | setVivadoPlanTclArgs tclArgs
+  | setVivadoPlanResources resources
+  | setVivadoPlanFnOutputs fnOutputs
+  | setVivadoPlanVisibleFiles allVisibleFiles
+  | runVivado
 
 tuple BitstreamOutputs =
   global Bitstream:    Path

--- a/fpga/mcs.wake
+++ b/fpga/mcs.wake
@@ -19,7 +19,7 @@ def vc707migHook =
   def addResources = "vivado/vc7071gmig/1.0"
   makeBlackBoxHook name addResources
 
-global target fpgaSynthOnly plan =
+global target runFPGASynthOnly plan =
     runVivadoWithPlan plan "fpga-shells/xilinx/common/tcl/synth-only.tcl"
 
 global target makeBitstream plan =
@@ -29,7 +29,7 @@ global target makeBitstream plan =
   vivadoBitstream.getVivadoOutputAllOutputs
   plan
 
-global target runVivadoWithPlan plan tclFile =
+target runVivadoWithPlan plan tclFile =
   def name = plan.getBitstreamPlanName
   def resources = plan.getBitstreamPlanResources
   def outputDir = plan.getBitstreamPlanOutputDir

--- a/top.wake
+++ b/top.wake
@@ -26,13 +26,13 @@ global topic vivadoBlackBoxResources : DUT => Option (List String)
 
 global def fpgaSynthTarget board dut buildRoot =
   setUpBitstream board dut buildRoot
-  | fpgaSynthOnly
+  | runFPGASynthOnly
 
 global def bitstreamTarget board dut buildRoot =
   setUpBitstream board dut buildRoot
   | makeBitstream
 
-global def setUpBitstream board dut buildRoot =
+def setUpBitstream board dut buildRoot =
   def name = dut.getDUTName
   def vendor = "xilinx"
   def tclFiles = filter (matches `.*\.vivado\.tcl` _.getPathName) dut.getDUTSources

--- a/top.wake
+++ b/top.wake
@@ -24,6 +24,36 @@ global def compileSimTarget dut buildRoot =
 global topic vivadoVsrcHooks : (dut: DUT) => Option (Unit => List Path)
 global topic vivadoBlackBoxResources : DUT => Option (List String)
 
+global def fpgaSynthTarget board dut buildRoot =
+  def name = dut.getDUTName
+  def vendor = "xilinx"
+  def tclFiles = filter (matches `.*\.vivado\.tcl` _.getPathName) dut.getDUTSources
+  def vsrcs =
+    subscribe vivadoVsrcHooks
+    | mapPartial (_ dut)
+    | map (_ Unit)
+    | flatten
+    | (dut.getDUTVsrcs ++ _)
+  def resources =
+    subscribe vivadoBlackBoxResources
+    | mapPartial (_ dut)
+    | map (sortBy (_<*_))
+    | flatten
+
+  def topModule = dut.getDUTTopModule
+
+  def visibleFiles =
+    sourcesInDUT `.*\.sdc` dut
+    ++ sourcesInDUT `.*\.xdc` dut
+    ++ sourcesInDUT `.*\.tcl` dut
+
+  makeBitstreamPlan name vendor board topModule buildRoot.getBuildTreeMCSDir
+  | setBitstreamPlanVsrcs vsrcs
+  | editBitstreamPlanResources(resources ++ _)
+  | setBitstreamPlanVisibleFiles visibleFiles
+  | setBitstreamPlanTclFiles tclFiles
+  | fpgaSynthOnly
+
 global def bitstreamTarget board dut buildRoot =
   def name = dut.getDUTName
   def vendor = "xilinx"

--- a/top.wake
+++ b/top.wake
@@ -25,36 +25,14 @@ global topic vivadoVsrcHooks : (dut: DUT) => Option (Unit => List Path)
 global topic vivadoBlackBoxResources : DUT => Option (List String)
 
 global def fpgaSynthTarget board dut buildRoot =
-  def name = dut.getDUTName
-  def vendor = "xilinx"
-  def tclFiles = filter (matches `.*\.vivado\.tcl` _.getPathName) dut.getDUTSources
-  def vsrcs =
-    subscribe vivadoVsrcHooks
-    | mapPartial (_ dut)
-    | map (_ Unit)
-    | flatten
-    | (dut.getDUTVsrcs ++ _)
-  def resources =
-    subscribe vivadoBlackBoxResources
-    | mapPartial (_ dut)
-    | map (sortBy (_<*_))
-    | flatten
-
-  def topModule = dut.getDUTTopModule
-
-  def visibleFiles =
-    sourcesInDUT `.*\.sdc` dut
-    ++ sourcesInDUT `.*\.xdc` dut
-    ++ sourcesInDUT `.*\.tcl` dut
-
-  makeBitstreamPlan name vendor board topModule buildRoot.getBuildTreeMCSDir
-  | setBitstreamPlanVsrcs vsrcs
-  | editBitstreamPlanResources(resources ++ _)
-  | setBitstreamPlanVisibleFiles visibleFiles
-  | setBitstreamPlanTclFiles tclFiles
+  setUpBitstream board dut buildRoot
   | fpgaSynthOnly
 
 global def bitstreamTarget board dut buildRoot =
+  setUpBitstream board dut buildRoot
+  | makeBitstream
+
+global def setUpBitstream board dut buildRoot =
   def name = dut.getDUTName
   def vendor = "xilinx"
   def tclFiles = filter (matches `.*\.vivado\.tcl` _.getPathName) dut.getDUTSources
@@ -82,7 +60,6 @@ global def bitstreamTarget board dut buildRoot =
   | editBitstreamPlanResources(resources ++ _)
   | setBitstreamPlanVisibleFiles visibleFiles
   | setBitstreamPlanTclFiles tclFiles
-  | makeBitstream
 
 global topic dutTests : DUTTest
 


### PR DESCRIPTION
pretty much copies of the main fpga paths that call different scripts. I thought about having these follow the same path but it seemed more difficult than it was worth, especially since these are mostly just used as a quick CI check to make sure there aren't any glaring issues