### PR TITLE
Use variable for rocket-chip location

### DIFF
--- a/dut/rocket-chip-dut.wake
+++ b/dut/rocket-chip-dut.wake
@@ -231,7 +231,7 @@ global topic dutSimExecuteOptionsHooks : DUT => Option (DUTSimExecuteOptions => 
 publish dutSimCompileOptionsHooks = rocketChipEICGSimCompileHook, Nil
 
 global def rocketChipEICGSimCompileHook =
-  def rocketChipVsrcs = "rocket-chip/src/main/resources/vsrc"
+  def rocketChipVsrcs = "{rocketChipRoot}/src/main/resources/vsrc"
   makeBlackBoxHook
   "EICG_wrapper"
   (editDUTSimCompileOptionsSourceFiles (source "{rocketChipVsrcs}/EICG_wrapper.v", _))

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -10,7 +10,7 @@
         "source": "git@github.com:sifive/freedom-devicetree-tools.git"
     },
     {
-        "commit": "43e2c8e776e1bde2e78914a08fe8963ca42ff1f0",
+        "commit": "5ede0829b7a926ffa29d2df8238dbfe44065128c",
         "name": "rocket-chip",
         "source": "git@github.com:chipsalliance/rocket-chip.git"
     },


### PR DESCRIPTION
(Also bumps rocket-chip in wit-manifest.json)

If rocket-chip were to change depth within the wit checkout layout, the consumers of rocket-chip would need to use this variable to find it.