### PR TITLE
Add wake 0.18.1 typecheck CI step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,7 @@ jobs:
         fetch-depth: 0
 
     - name: 'Wit Init'
-      # This commit is slightly past v0.13.0
-      # It adds /bin/bash to the docker container
-      uses: sifive/wit/actions/wit@97adca314832cefe4a4b609191699811def37be9
+      uses: sifive/wit/actions/wit@v0.13.1
       with:
         command: init
         arguments: |
@@ -37,3 +35,49 @@ jobs:
           --rm \
           sifive/environment-blockci:0.4.0 \
           api-generator-sifive/continuous-integration/run-tests.sh
+
+  typecheck:
+    name: 'Wake 0.18.1 typecheck'
+    runs-on: ubuntu-latest
+    env:
+      # $WIT_WORKSPACE path is relative to $GITHUB_WORKSPACE
+      WIT_WORKSPACE: wit-workspace
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: wit-packages/api-generator-sifive
+        # Fetch all history and tags
+        fetch-depth: 0
+
+    - name: 'Wit Init'
+      uses: sifive/wit/actions/wit@v0.13.1
+      with:
+        command: init
+        arguments: |
+          ${{ env.WIT_WORKSPACE }}
+          -a ./wit-packages/api-generator-sifive
+        force_github_https: true
+
+    - name: Run wake typecheck
+      working-directory: ${{ env.WIT_WORKSPACE }}
+      run: |
+        set -euxo pipefail
+
+        # Take back ownership of wit workspace, since it was created while
+        # under a Docker container and permissions default to root.
+        uid=$(id -u)
+        gid=$(id -g)
+        sudo chown -R "$uid:$gid" .
+
+        # Install Wake
+        curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.18.1/ubuntu-18-04-wake_0.18.1-1_amd64.deb && \
+            sudo dpkg -i /tmp/wake.deb && \
+            rm /tmp/wake.deb
+
+        # Initialize Wake workspace
+        wake --init .
+
+        # Run a dummy target, which still triggers a compilation of Wake code.
+        wake -x Unit
+

--- a/dut/drivers.wake
+++ b/dut/drivers.wake
@@ -26,6 +26,8 @@ tuple DriverImplementation =
 global def makeDriverImplementation compatibleDevices vendor deviceName driverSources includeDirs visible =
   DriverImplementation compatibleDevices vendor deviceName driverSources includeDirs visible
 
+topic driverImplementations: DriverImplementation
+
 target driverImpCompatibilityTrees Unit =
   subscribe driverImplementations
   | map (\p p → listToTree scmp p.getDriverImplementationCompatibilityStrings)

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -32,7 +32,7 @@
         "source": "git@github.com:sifive/devicetree-overlay-generator.git"
     },
     {
-        "commit": "cff1b713ac789bea21bcb794c6e376dd7d8ca8dc",
+        "commit": "795d65bc6c033c6d97222f2683f2112631558aa2",
         "name": "esdk-settings-generator",
         "source": "git@github.com:sifive/esdk-settings-generator.git"
     },


### PR DESCRIPTION
Adds a CI test for running type checking of the wake rules against the newer wake version (0.18.1)