### PR TITLE
Add VisibleFiles to DUTSimulator.

### DIFF
--- a/sim/dut-simulator.wake
+++ b/sim/dut-simulator.wake
@@ -124,9 +124,14 @@ tuple DUTSimCompileOptions =
   global SourceFiles:    List Path
   global Plusargs:       List NamedArg
   global Resources:      List String # resources to pass to the simulator `Plan`
+  # Files that should be visible to the simulator compiler but not passed in as
+  # direct source files. This should generally be used in conjuction with
+  # IncludeDirs and LibraryDirs in order to make files within those directories
+  # visible to the simulator compiler.
+  global VisibleFiles:   List Path
 
 global def makeDUTSimCompileOptions includeDirs defines sourceFiles plusargs =
-  DUTSimCompileOptions includeDirs Nil defines sourceFiles plusargs Nil
+  DUTSimCompileOptions includeDirs Nil defines sourceFiles plusargs Nil Nil
 
 global def emptyDUTSimCompileOptions = makeDUTSimCompileOptions Nil Nil Nil Nil
 
@@ -134,7 +139,7 @@ global def withDUTSimCompileOptions dut dutSimCompileOptions =
   dutSimCompileOptions
   | editDUTSimCompileOptionsSourceFiles (dut.getDUTVsrcs ++ _)
 
-global def appendDUTSimCompileOptions (DUTSimCompileOptions includes libraryDirs defines srcs plusargs resources) options =
+global def appendDUTSimCompileOptions (DUTSimCompileOptions includes libraryDirs defines srcs plusargs resources visible) options =
   options
   | editDUTSimCompileOptionsIncludeDirs  (_ ++ includes)
   | editDUTSimCompileOptionsLibraryDirs  (_ ++ libraryDirs)
@@ -142,8 +147,9 @@ global def appendDUTSimCompileOptions (DUTSimCompileOptions includes libraryDirs
   | editDUTSimCompileOptionsSourceFiles  (_ ++ srcs)
   | editDUTSimCompileOptionsPlusargs     (_ ++ plusargs)
   | editDUTSimCompileOptionsResources    (_ ++ resources)
+  | editDUTSimCompileOptionsVisibleFiles (_ ++ visible)
 
-global def prependDUTSimCompileOptions (DUTSimCompileOptions includes libraryDirs defines srcs plusargs resources) options =
+global def prependDUTSimCompileOptions (DUTSimCompileOptions includes libraryDirs defines srcs plusargs resources visible) options =
   options
   | editDUTSimCompileOptionsIncludeDirs  (includes ++ _)
   | editDUTSimCompileOptionsLibraryDirs  (libraryDirs ++ _)
@@ -151,6 +157,7 @@ global def prependDUTSimCompileOptions (DUTSimCompileOptions includes libraryDir
   | editDUTSimCompileOptionsSourceFiles  (srcs ++ _)
   | editDUTSimCompileOptionsPlusargs     (plusargs ++ _)
   | editDUTSimCompileOptionsResources    (resources ++ _)
+  | editDUTSimCompileOptionsVisibleFiles (visible ++ _)
 
 
 tuple DUTSimExecuteOptions =

--- a/sim/vcs-sim.wake
+++ b/sim/vcs-sim.wake
@@ -33,6 +33,7 @@ def toVCSSimCompilePlan privateOpts outputDir coverage =
   def plusargs     = dutOpts.getDUTSimCompileOptionsPlusargs
   def extraArgs    = privateOpts.getPrivateVCSDUTSimCompileOptionsExtraArgs
   def extraLibraryDirs = privateOpts.getPrivateVCSDUTSimCompileOptionsLibraryDirs
+  def visibleFiles = dutOpts.getDUTSimCompileOptionsVisibleFiles
   def withCoverage coverageEnabled plan =
     def editFn oldMetrics =
       if coverageEnabled then defaultCoverageMetrics else oldMetrics
@@ -45,6 +46,7 @@ def toVCSSimCompilePlan privateOpts outputDir coverage =
   | setVCSCompilePlanLibraryDirs (libraryDirs ++ extraLibraryDirs)
   | setVCSCompilePlanDefines     defines
   | setVCSCompilePlanPlusargs    plusargs
+  | setVCSCompilePlanVisible     visibleFiles
   | withCoverage                 coverage
 
 tuple PrivateVCSDUTSimExecuteOptions =

--- a/sim/verilator-sim.wake
+++ b/sim/verilator-sim.wake
@@ -43,6 +43,7 @@ def toVerilatorSimCompilePlan privateOpts outputDir coverage =
   def sourceFiles  = dutOpts.getDUTSimCompileOptionsSourceFiles
   def plusargs     = dutOpts.getDUTSimCompileOptionsPlusargs
   def resources    = dutOpts.getDUTSimCompileOptionsResources
+  def visibleFiles = dutOpts.getDUTSimCompileOptionsVisibleFiles
 
   def makeArgs     = privateOpts.getPrivateVerilatorDUTSimCompileOptionsMakeArgs
   def extraArgs    = privateOpts.getPrivateVerilatorDUTSimCompileOptionsExtraArgs
@@ -64,6 +65,7 @@ def toVerilatorSimCompilePlan privateOpts outputDir coverage =
   | setVerilatorCompilePlanPlusargs    plusargs
   | setVerilatorCompilePlanPrefix      prefix
   | setVerilatorCompilePlanResources   resources
+  | setVerilatorCompilePlanVisible     visibleFiles
   | withCoverage                       coverage
 
 global topic verilatorDUTSimCompileOptionsHooks : DUT => Option (PrivateVerilatorDUTSimCompileOptions => PrivateVerilatorDUTSimCompileOptions)

--- a/sim/xcelium-sim.wake
+++ b/sim/xcelium-sim.wake
@@ -33,6 +33,7 @@ def toXceliumSimCompilePlan privateOpts outputDir coverage =
   def sourceFiles    = dutOpts.getDUTSimCompileOptionsSourceFiles
   def plusargs       = dutOpts.getDUTSimCompileOptionsPlusargs
   def resources      = dutOpts.getDUTSimCompileOptionsResources
+  def visibleFiles   = dutOpts.getDUTSimCompileOptionsVisibleFiles
   def extraArgs      = privateOpts.getPrivateXceliumDUTSimCompileOptionsExtraArgs
   def extraLibraryDirs = privateOpts.getPrivateXceliumDUTSimCompileOptionsLibraryDirs
   def withCoverage coverageEnabled plan =
@@ -47,6 +48,7 @@ def toXceliumSimCompilePlan privateOpts outputDir coverage =
   | setXceliumCompilePlanLibraryDirs    (libraryDirs ++ extraLibraryDirs)
   | setXceliumCompilePlanDefines        defines
   | setXceliumCompilePlanPlusargs       plusargs
+  | setXceliumCompilePlanVisible        visibleFiles
   | withCoverage                        coverage
 
 

--- a/sim/xcelium.wake
+++ b/sim/xcelium.wake
@@ -6,6 +6,7 @@ tuple XceliumCompilePlan =
   global SourceFiles: List Path
   global Plusargs:    List NamedArg
   global ExtraArgs:   List NamedArg
+  global Visible:     List Path
   global FHomeDir:    String # func from output dir to home dir
   global OutputDir:   String
   global CoverageMetrics: XceliumCoverageMetrics
@@ -21,6 +22,7 @@ global def makeXceliumCompilePlan sourceFiles outputDir =
   sourceFiles        # Files
   Nil                # Plusargs
   Nil                # ExtraArgs
+  Nil                # Visible
   "{outputDir}/home" # FHomeDir
   outputDir          # OutputDir
   makeXceliumCoverageMetrics # CoverageMetrics
@@ -62,12 +64,13 @@ def compileInputs options =
   def libraryDirs  = options.getXceliumCompilePlanLibraryDirs
   def srcFiles     = options.getXceliumCompilePlanSourceFiles
   def homeDir      = options.getXceliumCompilePlanFHomeDir
+  def visibleFiles = options.getXceliumCompilePlanVisible
 
   def includeSources = map (sources _ `.*`) includeDirs | flatten
   def librarySources = map (sources _ `.*`) libraryDirs | flatten
   def homeSources = sources homeDir `.*`
 
-  source xrunWrapperScript, mkdir outputDir, includeSources ++ librarySources ++ srcFiles ++ homeSources
+  source xrunWrapperScript, mkdir outputDir, includeSources ++ librarySources ++ srcFiles ++ homeSources ++ visibleFiles
 
 global def doXceliumCompile options =
   def outputDir = options.getXceliumCompilePlanOutputDir


### PR DESCRIPTION
We did not previously have an API for adding files that should be visible (in the sense of Wake `Plan`s) to the simulator compiler, which meant that it was not possible to pass in Paths to files within library directories or include directories to the RTL simulators, short of passing in those files as source file arguments.

Example of where this is a problem:

- `main.sv` does a `` `include`` of `lib_a.sv`. `main.sv` is dynamically generated and may or may not actually include `lib_a.sv`
- `lib_a.sv` is located in a directory named `mylibs/`
- `lib_a.sv` may not always compile depending on factors related to when `main.sv` would include `lib_a.sv` in the first place

When you call `vcs +incdir+mylibs/ main.sv lib_a.sv`, it will be able to locate and include `lib_a.sv` and it will also compile fine. In the case where `lib_a.sv` should not be included/compiled, this will fail because `lib_a.sv` is not compilable, but `main.sv` didn't even want to include it in the first place. Normally this would not be a problem because you would just omit `lib_a.sv` from the command line, and VCS would only include and compile the files that are `` `include`d in the Verilog source.

When you call `vcs +incdir+mylibs/ main.sv` outside of Wake, it will normally be able to search for `lib_a.sv` in `mylibs/`, since this functions just like `-I` in `gcc`.

When you call `vcs +incdir+mylibs/ main.sv` from Wake but without `lib_a.sv` in the Wake visible file list, it won't be able to find and include the file.

Sorry for the not-so-great explanation above, but the bottom line is that we should have an API for allowing people to pass in directories of files that could be included, but should not necessarily be always be compiled.

What this translated to in code was adding a `VisibleFiles` property to `DutSimCompileOptions` and threading that through to the individual simulator compile rules. Note that Xcelium was special out of the three because it didn't already have a property for Visible files, so I had to add that to that simulator tuple as well.

I only tested this on VCS, but I think this is relatively safe to merge because it's the same change made for each simulator.