### PR TITLE
apply Hart Selection from devicetree-overlay-generator

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -20,7 +20,7 @@
         "source": "git@github.com:sifive/api-languages-sifive.git"
     },
     {
-        "commit": "6b8201670e686277f2e3e8af2d5ef78d42900b13",
+        "commit": "7bababb49f38af447af54491eae6e562fe82c92c",
         "name": "devicetree-overlay-generator",
         "source": "git@github.com:sifive/devicetree-overlay-generator.git"
     },


### PR DESCRIPTION
Hi team,

I've updated wit-manifest.json for devicetree-overlay-generator for applying Boot Hart Selection.

For detailed information, check the below

---
I'd like to make it possible to overlay boothart in wake flow, because some of core complex can have only u74 harts. (Chronos has U74x4 only)

example)


```
global def test _ =
  def entry = makeDevicetreeChosenMemoryEntry "/soc/bootrom@20000000" 0 0
  def ram = makeDevicetreeChosenMemoryRam "/soc/sram@80000000" 0 0
  def itim = None
  def chosenNode =
    makeDevicetreeChosenNode entry ram itim
    | setDevicetreeChosenNodeHart(Some(makeDevicetreeChosenBootHart "/cpus/cpu@0"))
  makeDevicetreeCustomOverlay ("core.dts", Nil) chosenNode | (writeDevicetreeCustomOverlay "design.dts" _)
```
---
The original PR (which has been merged) is as below.
https://github.com/sifive/devicetree-overlay-generator/pull/36
